### PR TITLE
reducing anonymous object creation

### DIFF
--- a/superficial/src/main/scala/superficial/EdgePair.scala
+++ b/superficial/src/main/scala/superficial/EdgePair.scala
@@ -1,25 +1,15 @@
 package superficial
 
-class EdgePair(initial: Vertex, terminal: Vertex) { pair =>
-  case object Positive extends OrientedEdge {
-    val initial = pair.initial
-    val terminal = pair.terminal
+class EdgePair(val initial: Vertex, val terminal: Vertex) { pair =>
+  lazy val  Positive = EdgePair.Oriented(pair, true)
 
-    val positivelyOriented: Boolean = true
+  lazy val Negative = EdgePair.Oriented(pair, false)
+}
 
-    lazy val flip: OrientedEdge = Negative
-
-    override def toString = s"$pair.positive"
-  }
-
-  case object Negative extends OrientedEdge {
-    val initial = pair.terminal
-    val terminal = pair.initial
-
-    val positivelyOriented: Boolean = false
-
-    lazy val flip: OrientedEdge = Positive
-
-    override def toString = s"$pair.negative"
+object EdgePair{
+  case class Oriented(pair: EdgePair, positive: Boolean) extends Edge{
+    lazy val flip: Edge = Oriented(pair, !positive)
+    lazy val terminal: Vertex = if (positive) pair.terminal else pair.initial
+    lazy val initial: Vertex = if (positive) pair.initial else pair.terminal
   }
 }

--- a/superficial/src/main/scala/superficial/Quadrangulation.scala
+++ b/superficial/src/main/scala/superficial/Quadrangulation.scala
@@ -33,6 +33,14 @@ object Quadrangulation {
 
   case class QuadEdge(face: Polygon, index: Int) extends EdgePair(BaryCenter(face), face.boundary(index).terminal)
 
+
+  // The `bdy` parameter is redundant, but will need significant refactoring to avoid
+  case class QuadFace(complex: TwoComplex, edge: Edge, bdy: Vector[Edge]) extends Polygon{
+      val sides: Int = bdy.size
+      val boundary: Vector[Edge] = bdy
+      val vertices: Set[Vertex] = boundary.map(_.initial).toSet
+  }
+
   /**
    *Gives the quadrangulation of a twocomplex along maps from edgepaths from the twocomplex to  
    *paths in the quadragulation.
@@ -119,7 +127,7 @@ object Quadrangulation {
           (newEdgeMap1(face, mod(indexOfEdge - 1, periOfFace)).Negative)),
           (newEdgeMap1(face, indexOfEdge).Positive))     
 
-      val newFace = Polygon(
+      val newFace = QuadFace(twoComplex, edge,
         dualFaceBoundary(edge)
       )
 

--- a/superficial/src/main/scala/superficial/Quadrangulation.scala
+++ b/superficial/src/main/scala/superficial/Quadrangulation.scala
@@ -29,6 +29,10 @@ object Quadrangulation {
         twoComplex.asInstanceOf[Quadrangulation]
     }
 
+  case class BaryCenter(face: Polygon) extends Vertex
+
+  case class QuadEdge(face: Polygon, index: Int) extends EdgePair(BaryCenter(face), face.boundary(index).terminal)
+
   /**
    *Gives the quadrangulation of a twocomplex along maps from edgepaths from the twocomplex to  
    *paths in the quadragulation.
@@ -54,17 +58,12 @@ object Quadrangulation {
     val faceList = twoComplex.faces.toList
     val facesWithIndexes :  List[(Polygon, Int)] = faceList.flatMap(f => ((0 to (f.boundary.length - 1)).map(ind => (f, ind))))
 
-    def createBarycenter (face : Polygon) : Vertex = {
-      object bFace extends Vertex
-      bFace
-    } 
+    def createBarycenter (face : Polygon) : Vertex = BaryCenter(face)
 
     val barycentersList = faceList.map(createBarycenter(_))
     val barycenters = faceList.zip(barycentersList).toMap
 
-    def createEdgePairs (face : Polygon, index : Int) : EdgePair = {
-      new EdgePair(barycenters(face), face.boundary(index).terminal)
-    }
+    def createEdgePairs (face : Polygon, index : Int) : EdgePair = QuadEdge(face, index)
 
     val newEdgeMap1 : Map[(Polygon, Int),EdgePair] = 
       facesWithIndexes.map{

--- a/superficial/src/main/scala/superficial/Quadrangulation.scala
+++ b/superficial/src/main/scala/superficial/Quadrangulation.scala
@@ -90,6 +90,21 @@ object Quadrangulation {
        assert(face != None, "For a closed surface each edge should be in at least one face")
        face.get
     }
+
+    def dualFaceBoundary(edge: Edge): Vector[Edge] = {
+      val face = faceOfEdge(edge)
+      val flipFace = faceOfEdge(edge.flip)
+      val indexOfEdge = face.boundary.indexOf(edge)
+      val indexOfFlip = flipFace.boundary.indexOf(edge.flip)
+      val periOfFace = face.boundary.length
+      val periOfFlip = flipFace.boundary.length
+      Vector(
+        newEdgeMap1(face, indexOfEdge).Positive, // from barycenter of face of edge to edge.terminal
+        newEdgeMap1(flipFace, mod(indexOfFlip - 1, periOfFlip)).Negative, // from edge.terminal to barycenter of face of edge.flip
+        newEdgeMap1(flipFace, indexOfFlip).Positive, // from barycenter of face of edge.flip to edge.initial
+        newEdgeMap1(face, mod(indexOfEdge - 1, periOfFace)).Negative // from edge.intial to barycenter of face of edge
+      )
+    }
     
     // creates the face corresponding the edge. Also gives an edgepath homotopic to the edge preserving endpoints
     def createFace (edge : Edge) : (Polygon, (Edge, EdgePath))= {
@@ -104,12 +119,9 @@ object Quadrangulation {
           (newEdgeMap1(face, mod(indexOfEdge - 1, periOfFace)).Negative)),
           (newEdgeMap1(face, indexOfEdge).Positive))     
 
-      val newFace = Polygon.apply(Vector(
-        newEdgeMap1(face, indexOfEdge).Positive, // from barycenter of face of edge to edge.terminal
-        newEdgeMap1(flipFace, mod(indexOfFlip - 1, periOfFlip)).Negative, // from edge.terminal to barycenter of face of edge.flip
-        newEdgeMap1(flipFace, indexOfFlip).Positive, // from barycenter of face of edge.flip to edge.initial
-        newEdgeMap1(face, mod(indexOfEdge - 1, periOfFace)).Negative // from edge.intial to barycenter of face of edge
-      ))
+      val newFace = Polygon(
+        dualFaceBoundary(edge)
+      )
 
       (newFace, (edge, edgePath))
     }  

--- a/superficial/src/main/scala/superficial/TwoComplex.scala
+++ b/superficial/src/main/scala/superficial/TwoComplex.scala
@@ -837,3 +837,7 @@ trait PureTwoComplex extends TwoComplex {
     faces.map(_.vertices).foldLeft(Set.empty[Vertex])(_ union _)
 }
 
+case class PureComplex(polys: Set[Polygon]) extends PureTwoComplex{
+  val faces: Set[Polygon] = polys
+}
+


### PR DESCRIPTION
Since face barycenter and quadrangulation edges are determined by data, case classes are used instead of creating anonymous objects.
@anotherArka see if the logic is correct.